### PR TITLE
GSR updates for PDC

### DIFF
--- a/src/main/java/com/boundlessgeo/gsr/GSRDispatcher.java
+++ b/src/main/java/com/boundlessgeo/gsr/GSRDispatcher.java
@@ -69,7 +69,7 @@ public class GSRDispatcher extends APIDispatcher {
 
             public List<MediaType> resolveMediaTypes(NativeWebRequest webRequest) {
                 String f = webRequest.getParameter("f");
-                if ("json".equals(f)) {
+                if ("json".equals(f) || "pjson".equals(f)) {
                     return Collections.singletonList(MediaType.APPLICATION_JSON);
                 } else if ("geojson".equals(f)) {
                     return Collections.singletonList(MediaType.parseMediaType("application/geo+json"));

--- a/src/main/java/com/boundlessgeo/gsr/api/feature/FeatureLayerListController.java
+++ b/src/main/java/com/boundlessgeo/gsr/api/feature/FeatureLayerListController.java
@@ -1,0 +1,45 @@
+/* (c) 2019 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package com.boundlessgeo.gsr.api.feature;
+
+import com.boundlessgeo.gsr.api.AbstractGSRController;
+import com.boundlessgeo.gsr.model.AbstractGSRModel.Link;
+import com.boundlessgeo.gsr.model.map.LayersAndTables;
+import com.boundlessgeo.gsr.translate.map.LayerDAO;
+import java.util.Arrays;
+import org.geoserver.api.HTMLResponseBody;
+import org.geoserver.config.GeoServer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for the Feature Service layers list endpoint
+ */
+@RestController
+@RequestMapping(path = "/gsr/services/{workspaceName}/FeatureServer", produces = MediaType.APPLICATION_JSON_VALUE)
+public class FeatureLayerListController extends AbstractGSRController {
+
+    @Autowired
+    public FeatureLayerListController(@Qualifier("geoServer") GeoServer geoServer) {
+        super(geoServer);
+    }
+
+    @GetMapping(path = "/layers", name = "FeatureServerGetLayers")
+    @HTMLResponseBody(templateName = "featurelayers.ftl", fileName = "featurelayers.html")
+    public LayersAndTables getLayers(@PathVariable String workspaceName) {
+        LayersAndTables layers = LayerDAO.find(catalog, workspaceName);
+        layers.getPath().addAll(Arrays.asList(
+                new Link(workspaceName, workspaceName),
+                new Link(workspaceName + "/" + "FeatureServer", "FeatureServer")
+        ));
+        layers.getInterfaces().add(new Link(workspaceName + "/" + "FeatureServer/layers?f=json&pretty=true", "REST"));
+        return layers;
+    }
+}

--- a/src/main/resources/com/boundlessgeo/gsr/api/feature/featurelayers.ftl
+++ b/src/main/resources/com/boundlessgeo/gsr/api/feature/featurelayers.ftl
@@ -1,0 +1,10 @@
+<#include "common-header.ftl">
+<#include "breadcrumbs.ftl">
+<#include "layer.ftl">
+    <p><b>Layers:</b></p>
+   <#list model.layers as layer>
+   <#call layerDescription(layer, "Layer")>
+   </#list>
+   <p><b>Tables:</b></p><!-- TODO ??? -->
+   <#include "interfaces.ftl">
+<#include "common-footer.ftl">


### PR DESCRIPTION
This pull request includes changes made to the GSR extension in order to make it work with PDC's application.  An endpoint for listing all layers in a Feature Service was added to match what is available in ArcGIS Server.  Also, added a minor change to return json instead of an error if a client tries to request the format pjson which is supported by ArcGIS Server.  While it would be ideal if the extension actually supported pjson ("Pretty JSON"), this update is a simple solution to keep clients that have been programmed to request pjson from breaking.